### PR TITLE
update MutatingWebhookConfiguration API from beta1 to v1

### DIFF
--- a/deployment/mutatingwebhook.yaml
+++ b/deployment/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-gtoken-webhook-cfg


### PR DESCRIPTION
* Remove `v1beta1` api since it's deprecated in Kubernetes 1.22 now.