### PR TITLE
Update Drone file golangci-lint installer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,14 +13,14 @@ steps:
   - name: lint gtoken
     image: golang:1.16
     commands:
-      - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
       - cd cmd/gtoken
       - go build ./...
       - golangci-lint run
   - name: lint gtoken-webhook
     image: golang:1.16
     commands:
-      - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VERSION
       - cd cmd/gtoken-webhook
       - go build ./...
       - golangci-lint run


### PR DESCRIPTION
goreleaser/godownloader is deprecated and needs to be replaced

[_Created by Sourcegraph batch change `wmeng/drone-golangci-lint-installer`._](https://shipt.sourcegraph.com/users/wmeng/batch-changes/drone-golangci-lint-installer)